### PR TITLE
Fixed token refresh functionality, and ensured old session was clear

### DIFF
--- a/okta_widget/api.py
+++ b/okta_widget/api.py
@@ -341,7 +341,7 @@ def setNameId(request, token):
         version = '{}'.format(IMPERSONATION_VERSION)
         if version == "1":
             client = AppsClient('https://' + OKTA_ORG, API_KEY, IMPERSONATION_SAML_APP_ID)
-            response.status_code = client.set_name_id(request.session['user_id'], post['nameid'])
+            response.status_code = client.set_name_id(request.session['id_token']['sub'], post['nameid'])
         if version == "2":
             u_client = UsersClient('https://' + IMPERSONATION_V2_ORG, IMPERSONATION_V2_ORG_API_KEY)
             profile = request.session['profile']

--- a/okta_widget/views.py
+++ b/okta_widget/views.py
@@ -209,6 +209,8 @@ def view_login_auto(request):
         return _do_refresh(request, page)
     else:
         c.update({"js": _do_format(request, '/js/get_without_prompt.js', page)})
+    #Lets ensure everything is cleared out and refreshed.
+    logout(request)
     return render(request, 'index_get_without_prompt.html', c)
 
 

--- a/static/js/get_without_prompt.js
+++ b/static/js/get_without_prompt.js
@@ -33,6 +33,5 @@ function showApp(res) {
         key = Object.keys(res[1])[0];
         authClient.tokenManager.add(key, res[1]);
     }
-    post_tokens(oktaSignIn.tokenManager.get('idToken'), oktaSignIn.tokenManager.get('accessToken'));
-    get_profile(key, authClient.tokenManager.get(key));
+    post_tokens(authClient.tokenManager.get('idToken'), authClient.tokenManager.get('accessToken'));
 }


### PR DESCRIPTION
-Found that i was still trying to pull tokens from the sign-in widget on the token refresh page- when i should have been pulling from the auth-js object instead- fixed.

-Ensuring session is wiped when pulling new tokens

-Found another location where session variable was unpacked.